### PR TITLE
Fix op-in regions not working for AMP

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -79,7 +79,7 @@ type SessionConfig struct {
 	AuthSettings  *AuthSettings
 }
 
-func isOptInRegion(region string) bool {
+func IsOptInRegion(region string) bool {
 	// Opt-in region from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
 	regions := map[string]bool{
 		"af-south-1":     true,
@@ -168,7 +168,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 		c.Settings.Region = ""
 	}
 	if c.Settings.Region != "" {
-		if c.Settings.AssumeRoleARN != "" && c.AuthSettings.AssumeRoleEnabled && isOptInRegion(c.Settings.Region) {
+		if c.Settings.AssumeRoleARN != "" && c.AuthSettings.AssumeRoleEnabled && IsOptInRegion(c.Settings.Region) {
 			// When assuming a role, the real region is set later in a new session
 			// so we use a well-known region here (not opt-in) to obtain valid credentials
 			regionCfg = &aws.Config{Region: aws.String("us-east-1")}

--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -84,6 +84,7 @@ func IsOptInRegion(region string) bool {
 	regions := map[string]bool{
 		"af-south-1":     true,
 		"ap-east-1":      true,
+		"ap-east-2":      true,
 		"ap-south-2":     true,
 		"ap-southeast-3": true,
 		"ap-southeast-4": true,

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -212,6 +212,9 @@ func createSigner(cfg *Config, verboseMode bool) (*v4.Signer, error) {
 	}
 	assumeRoleRegion := aws.String(cfg.Region)
 	if awsds.IsOptInRegion(cfg.Region) {
+        // AMG: Currently the auth middleware for Prometheus doesn’t support assuming role to opt-in regions, so we query from non-opt-in region.
+        // This will be superseded by proper opt-in regions support for prometheus in a later version.
+        // https://github.com/grafana/grafana/issues/107199
 		assumeRoleRegion = aws.String("us-east-1")
 	}
 


### PR DESCRIPTION
Fix op-in regions not working for AMP. Cherry-picked from this [commit](https://github.com/grafana/grafana-aws-sdk/commit/1604fc05fc61096d9496dd1d3ee5364eef05717f).

Also adds `ap-east-2` new opt-in region from [docs](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html).

[SIM](https://t.corp.amazon.com/P247915531/communication)

Tested in alpha. We were able to query metrics in `af-south-1`.