### PR TITLE
Add missing ap-southeast-6 opt in region

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -89,6 +89,7 @@ func IsOptInRegion(region string) bool {
 		"ap-southeast-3": true,
 		"ap-southeast-4": true,
 		"ap-southeast-5": true,
+		"ap-southeast-6": true,
 		"ap-southeast-7": true,
 		"ca-west-1":      true,
 		"eu-central-2":   true,


### PR DESCRIPTION
Backport https://github.com/grafana/grafana-aws-sdk/pull/355

SIM: https://t.corp.amazon.com/P324266783